### PR TITLE
feat(seo): add script to generate dynamic sitemap

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  webpack: (config, { isServer }) => {
+    if (isServer) {
+      require("./scripts/generate-sitemap");
+    }
+    return config;
+  }
+};

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/react": "^17.0.8",
     "@types/react-dom": "^17.0.5",
     "babel-loader": "^8.2.2",
+    "globby": "^11.0.4",
     "storybook-css-modules-preset": "^1.1.1",
     "typescript": "4.3"
   },

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
+Allow: /
+Host: https://oscafrica.org
 Sitemap: https://oscafrica.org/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,32 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset
-      xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
-            http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
-<!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://oscafrica.org/about-us</loc>
+    <lastmod>2021-07-10T08:18:42.785Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.80</priority>
+  </url>
 
+  <url>
+    <loc>https://oscafrica.org/community</loc>
+    <lastmod>2021-07-10T08:18:42.785Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.80</priority>
+  </url>
 
-<url>
-  <loc>https://www.oscafrica.org/</loc>
-  <lastmod>2021-07-08T18:27:06+00:00</lastmod>
-  <priority>1.00</priority>
-</url>
-<url>
-  <loc>https://www.oscafrica.org/team</loc>
-  <lastmod>2021-07-08T18:27:06+00:00</lastmod>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://www.oscafrica.org/about-us</loc>
-  <lastmod>2021-07-08T18:27:06+00:00</lastmod>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://www.oscafrica.org/community</loc>
-  <lastmod>2021-07-08T18:27:06+00:00</lastmod>
-  <priority>0.80</priority>
-</url>
+  <url>
+    <loc>https://oscafrica.org/</loc>
+    <lastmod>2021-07-10T08:18:42.785Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.00</priority>
+  </url>
 
-
+  <url>
+    <loc>https://oscafrica.org/team</loc>
+    <lastmod>2021-07-10T08:18:42.785Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.80</priority>
+  </url>
 </urlset>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,0 +1,44 @@
+const fs = require("fs");
+const globby = require("globby");
+const prettier = require("prettier");
+
+(async () => {
+  const prettierConfig = await prettier.resolveConfig("./.prettierrc");
+
+  const pages = await globby([
+    "src/pages/**/*.{js,jsx,ts,tsx,mdx}", // All routes inside src/pages
+    "!src/pages/**/[*.{js,jsx,ts,tsx,mdx}", // Ignore dynamic routes (e.g /pages/blog/[slug].tsx)
+    "!src/pages/_*.{js,jsx,ts,tsx}", // Ignore Next.js files
+    "!src/pages/api" // Ignore API routes
+  ]);
+  const sitemap = `
+  <?xml version="1.0" encoding="UTF-8"?>
+  <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+            ${pages
+              .map((page) => {
+                const path = page.replace("src/pages", "").replace(/\.[^/.]+$/, ""); // Remove "src/pages" and file extension
+                const indexPath = path === "/index";
+                const route = indexPath ? path.replace("/index", "/") : path;
+                const changeFreq = "<changefreq>weekly</changefreq>";
+                const priority = indexPath ? "<priority>1.00</priority>" : "<priority>0.80</priority>";
+
+                return `
+                        <url>
+                            <loc>${`https://oscafrica.org${route}`}</loc>
+                            <lastmod>${new Date().toISOString()}</lastmod>
+                            ${changeFreq}
+                            ${priority}
+                        </url>
+                    `;
+              })
+              .join("")}
+        </urlset>
+    `;
+
+  const formatted = prettier.format(sitemap, {
+    ...prettierConfig,
+    parser: "html"
+  });
+
+  fs.writeFileSync("public/sitemap.xml", formatted);
+})();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6144,6 +6144,18 @@ globby@11.0.1:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
+globby@^11.0.4:
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
+  integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
+
 globby@^9.2.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-9.2.0.tgz#fd029a706c703d29bdd170f4b6db3a3f7a7cb63d"


### PR DESCRIPTION
<!-- Love osca? Please consider supporting our collective:
👉  https://opencollective.com/osca/donate -->

#### What does this PR do

Generate `sitemap.xml` dynamically from all present pages.

#### How should this be manually tested

Add a new page and run `npm run build` (don't forget to delete the page, please).

#### What are the relevant issues this PR belongs to

#29 

#### Any background context you want to add

N/A

